### PR TITLE
fix(docker): add sendmail os package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN \
     php8.2-bcmath \
     php8.2-intl \
     php8.2-curl \
+    sendmail \
     sqlite3 \
     curl \
     git \


### PR DESCRIPTION
Allow users to use OS sendmail for sending mail.

closes: #27