### PR TITLE
fix(docker): add default-mysql-client os package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN \
     php8.2-intl \
     php8.2-curl \
     sqlite3 \
+    default-mysql-client \
     curl \
     git \
     jpegoptim \


### PR DESCRIPTION
Allow users to use mysqldump to backup the database from the UI.

closes: #29