### PR TITLE
 fix(docker): add postgresql-client os package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     sendmail \
     sqlite3 \
     default-mysql-client \
+    postgresql-client \
     curl \
     git \
     jpegoptim \


### PR DESCRIPTION
Allow users to use pg_dump to backup the database from the UI.